### PR TITLE
Add prefix ALS_ to B, C, D defined name

### DIFF
--- a/src/APDS9930.cpp
+++ b/src/APDS9930.cpp
@@ -354,17 +354,21 @@ bool APDS9930::readAmbientLightLux(unsigned long &val)
 
 float APDS9930::floatAmbientToLux(uint16_t Ch0, uint16_t Ch1)
 {
+	uint8_t x[4]={1,8,16,120};
     float ALSIT = 2.73 * (256 - DEFAULT_ATIME);
     float iac  = max(Ch0 - ALS_B * Ch1, ALS_C * Ch0 - ALS_D * Ch1);
-    float lpc  = GA * DF / (ALSIT * getAmbientLightGain());
+    if (iac < 0) iac = 0;
+	float lpc  = GA * DF / (ALSIT * x[getAmbientLightGain()]);
     return iac * lpc;
 }
 
 unsigned long APDS9930::ulongAmbientToLux(uint16_t Ch0, uint16_t Ch1)
 {
+	uint8_t x[4]={1,8,16,120};
     unsigned long ALSIT = 2.73 * (256 - DEFAULT_ATIME);
     unsigned long iac  = max(Ch0 - ALS_B * Ch1, ALS_C * Ch0 - ALS_D * Ch1);
-    unsigned long lpc  = GA * DF / (ALSIT * getAmbientLightGain());
+	if (iac < 0) iac = 0;
+    unsigned long lpc  = GA * DF / (ALSIT * x[getAmbientLightGain()]);
     return iac * lpc;
 }
 
@@ -716,7 +720,7 @@ bool APDS9930::setProximityDiode(uint8_t drive)
  *   0        1x
  *   1        4x
  *   2       16x
- *   3       64x
+ *   3      120x
  *
  * @return the value of the ALS gain. 0xFF on failure.
  */
@@ -731,7 +735,7 @@ uint8_t APDS9930::getAmbientLightGain()
     
     /* Shift and mask out ADRIVE bits */
     val &= 0b00000011;
-    
+	
     return val;
 }
 

--- a/src/APDS9930.cpp
+++ b/src/APDS9930.cpp
@@ -354,21 +354,17 @@ bool APDS9930::readAmbientLightLux(unsigned long &val)
 
 float APDS9930::floatAmbientToLux(uint16_t Ch0, uint16_t Ch1)
 {
-	uint8_t x[4]={1,8,16,120};
     float ALSIT = 2.73 * (256 - DEFAULT_ATIME);
-    float iac  = max(Ch0 - B * Ch1, C * Ch0 - D * Ch1);
-    if (iac < 0) iac = 0;
-	float lpc  = GA * DF / (ALSIT * x[getAmbientLightGain()]);
+    float iac  = max(Ch0 - ALS_B * Ch1, ALS_C * Ch0 - ALS_D * Ch1);
+    float lpc  = GA * DF / (ALSIT * getAmbientLightGain());
     return iac * lpc;
 }
 
 unsigned long APDS9930::ulongAmbientToLux(uint16_t Ch0, uint16_t Ch1)
 {
-	uint8_t x[4]={1,8,16,120};
     unsigned long ALSIT = 2.73 * (256 - DEFAULT_ATIME);
-    unsigned long iac  = max(Ch0 - B * Ch1, C * Ch0 - D * Ch1);
-	if (iac < 0) iac = 0;
-    unsigned long lpc  = GA * DF / (ALSIT * x[getAmbientLightGain()]);
+    unsigned long iac  = max(Ch0 - ALS_B * Ch1, ALS_C * Ch0 - ALS_D * Ch1);
+    unsigned long lpc  = GA * DF / (ALSIT * getAmbientLightGain());
     return iac * lpc;
 }
 
@@ -720,7 +716,7 @@ bool APDS9930::setProximityDiode(uint8_t drive)
  *   0        1x
  *   1        4x
  *   2       16x
- *   3      120x
+ *   3       64x
  *
  * @return the value of the ALS gain. 0xFF on failure.
  */
@@ -735,7 +731,7 @@ uint8_t APDS9930::getAmbientLightGain()
     
     /* Shift and mask out ADRIVE bits */
     val &= 0b00000011;
-	
+    
     return val;
 }
 

--- a/src/APDS9930.h
+++ b/src/APDS9930.h
@@ -112,7 +112,7 @@
 #define CLEAR_ALL_INTS          0xE7
 
 /* Default values */
-#define DEFAULT_ATIME           0xED
+#define DEFAULT_ATIME           0xFF
 #define DEFAULT_WTIME           0xFF
 #define DEFAULT_PTIME           0xFF
 #define DEFAULT_PPULSE          0x08
@@ -121,7 +121,7 @@
 #define DEFAULT_PDRIVE          LED_DRIVE_100MA
 #define DEFAULT_PDIODE          2
 #define DEFAULT_PGAIN           PGAIN_8X
-#define DEFAULT_AGAIN           AGAIN_1X
+#define DEFAULT_AGAIN           AGAIN_16X
 #define DEFAULT_PILT            0       // Low proximity threshold
 #define DEFAULT_PIHT            50      // High proximity threshold
 #define DEFAULT_AILT            0xFFFF  // Force interrupt for calibration
@@ -131,9 +131,9 @@
 /* ALS coefficients */
 #define DF                      52
 #define GA                      0.49
-#define B                       1.862
-#define C                       0.746
-#define D                       1.291
+#define ALS_B                       1.862
+#define ALS_C                       0.746
+#define ALS_D                       1.291
 
 /* State definitions */
 enum {

--- a/src/APDS9930.h
+++ b/src/APDS9930.h
@@ -112,7 +112,7 @@
 #define CLEAR_ALL_INTS          0xE7
 
 /* Default values */
-#define DEFAULT_ATIME           0xFF
+#define DEFAULT_ATIME           0xED
 #define DEFAULT_WTIME           0xFF
 #define DEFAULT_PTIME           0xFF
 #define DEFAULT_PPULSE          0x08
@@ -121,7 +121,7 @@
 #define DEFAULT_PDRIVE          LED_DRIVE_100MA
 #define DEFAULT_PDIODE          2
 #define DEFAULT_PGAIN           PGAIN_8X
-#define DEFAULT_AGAIN           AGAIN_16X
+#define DEFAULT_AGAIN           AGAIN_1X
 #define DEFAULT_PILT            0       // Low proximity threshold
 #define DEFAULT_PIHT            50      // High proximity threshold
 #define DEFAULT_AILT            0xFFFF  // Force interrupt for calibration


### PR DESCRIPTION
I add prefix "ALS_" to the ALS coefficients B, C. D name to prevent macro expanding while compiling ESP8266 project.Since there's a parameter named B  in bearssl_ec.h.